### PR TITLE
refactor getSampleTenants to update address format

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -16,53 +16,47 @@ import seedu.address.model.tenant.Tenant;
  */
 public class SampleDataUtil {
     public static Tenant[] getSampleTenants() {
-        return new Tenant[] {new Tenant(new Name("Alex", "Yeoh"),
-                /*
-                 * new Phone("87438807"), new Email( "alexyeoh@example.com"),
-                 */
-                new Address("Blk 30 Geylang Street 29, #06-40")
-                /* getTagSet("friends") */
-                ), new Tenant(new Name("Bernice", "Yu"),
-                        /*
-                         * new Phone ( "99272758" ) , new Email ( "berniceyu@example.com" ) ,
-                         */
-                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18")
-                /*
-                 * , getTagSet ( "colleagues", "friends")
-                 */
-                ), new Tenant(new Name("Charlotte", "Oliveiro"),
-                        /*
-                         * new Phone("93210283"), new Email( "charlotte@example.com" ),
-                         */
-                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04")
-                /*
-                 * , getTagSet ( "neighbours")
-                 */
-                ), new Tenant(new Name("David", "Li"),
-                        /*
-                         * new Phone("91031282"), new Email("lidavid@example.com"),
-                         */
-                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43")
-                /*
-                 * , getTagSet ( "family")
-                 */
-                ), new Tenant(new Name("Irfan", "Ibrahim"),
-                        /*
-                         * new Phone("92492021"), new Email("irfan@example.com"),
-                         */
-                        new Address("Blk 47 Tampines Street 20, #17-35")
-                /*
-                 * , getTagSet ( "classmates")
-                 */
-                ), new Tenant(new Name("Roy", "Balakrishnan"),
-                        /*
-                         * new Phone("92624417"), new Email("royb@example.com" ),
-                         */
-                        new Address("Blk 45 Aljunied Street 85, #11-31")
-                /*
-                 * , getTagSet ( "colleagues")
-                 */
-                )};
+        return new Tenant[]{new Tenant(new Name("Alex", "Yeoh"),
+            /*
+             * new Phone("87438807"), new Email( "alexyeoh@example.com"),
+             */
+            new Address("Blk 30 Geylang Street 29, #06-40 123456") /* getTagSet("friends") */
+        ), new Tenant(new Name("Bernice", "Yu"),
+            /*
+             * new Phone ( "99272758" ) , new Email ( "berniceyu@example.com" ) ,
+             */
+            new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18 123456") /*
+         * , getTagSet ( "colleagues", "friends")
+         */
+        ), new Tenant(new Name("Charlotte", "Oliveiro"),
+            /*
+             * new Phone("93210283"), new Email( "charlotte@example.com" ),
+             */
+            new Address("Blk 11 Ang Mo Kio Street 74, #11-04 123457") /*
+         * , getTagSet ( "neighbours")
+         */
+        ), new Tenant(new Name("David", "Li"),
+            /*
+             * new Phone("91031282"), new Email("lidavid@example.com"),
+             */
+            new Address("Blk 436 Serangoon Gardens Street 26, #16-43 123458") /*
+         * , getTagSet ( "family")
+         */
+        ), new Tenant(new Name("Irfan", "Ibrahim"),
+            /*
+             * new Phone("92492021"), new Email("irfan@example.com"),
+             */
+            new Address("Blk 47 Tampines Street 20, #17-35 123459") /*
+         * , getTagSet ( "classmates")
+         */
+        ), new Tenant(new Name("Roy", "Balakrishnan"),
+            /*
+             * new Phone("92624417"), new Email("royb@example.com" ),
+             */
+            new Address("Blk 45 Aljunied Street 85, #11-31 123451") /*
+         * , getTagSet ( "colleagues")
+         */
+        )};
     }
 
     public static ReadOnlyTenantTracker getSampleTenantTracker() {


### PR DESCRIPTION
Previously, tenant addresses did not include postal codes, which may lead to inconsistencies when processing
address-based operations. The format was
updated to append a six-digit postal code to each address.

This change ensures a standardised address format, improving data integrity and consistency
when handling tenant information.