### PR TITLE
FilterCommand: Add address-based filtering feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'application'
     id 'jacoco'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.22'
 }
 
 mainClassName = 'seedu.address.Main'
@@ -63,6 +64,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 shadowJar {
@@ -70,3 +72,13 @@ shadowJar {
 }
 
 defaultTasks 'clean', 'test'
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
+
+/**
+ * Filters for all persons in address book whose address contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class FilterCommand extends Command {
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Filters all persons whose addresses contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n" + "Example: " + COMMAND_WORD
+            + " Kent Ridge";
+
+    private final AddressContainsKeywordsPredicate predicate;
+
+    public FilterCommand(AddressContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTenantList(predicate);
+        return new CommandResult(String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW,
+                model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return predicate.equals(otherFilterCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("predicate", predicate).toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand
+     * and returns a FilterCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FilterCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FilterCommand(new AddressContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TenantTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/TenantTrackerParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -65,6 +66,9 @@ public class TenantTrackerParser {
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/tenant/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tenant/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.tenant;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Tenant}'s {@code Address} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Tenant> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Tenant tenant) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tenant.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddressContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        AddressContainsKeywordsPredicate otherPredicate = (AddressContainsKeywordsPredicate) other;
+        return keywords.equals(otherPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/data/JsonSerializableTenantTrackerTest/typicalTenantsTenantTracker.json
+++ b/src/test/data/JsonSerializableTenantTrackerTest/typicalTenantsTenantTracker.json
@@ -35,6 +35,21 @@
       "givenName": "George",
       "familyName": "Best",
       "address": "4th street, 123456"
+    },
+    {
+      "givenName": "James",
+      "familyName": "Smith",
+      "address": "21 Lower Kent Ridge Rd, 119077"
+    },
+    {
+      "givenName": "Mike",
+      "familyName": "Johnson",
+      "address": "21 Lower Kent Ridge Rd, 119077"
+    },
+    {
+      "givenName": "Oliver",
+      "familyName": "Jones",
+      "address": "21 Lower Kent Ridge Rd, 119077"
     }
   ]
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,131 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalTenants.JAMES;
+import static seedu.address.testutil.TypicalTenants.MIKE;
+import static seedu.address.testutil.TypicalTenants.OLIVER;
+import static seedu.address.testutil.TypicalTenants.getTypicalTenantTracker;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FilterCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalTenantTracker(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalTenantTracker(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        AddressContainsKeywordsPredicate firstPredicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("first"));
+        AddressContainsKeywordsPredicate secondPredicate =
+                new AddressContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different predicate -> returns false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    /**
+     * Tests the execution of {@code FilterCommand} when no keywords are provided.
+     * Verifies that no tenants are found.
+     */
+    @Test
+    public void execute_zeroKeywords_noTenantFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        AddressContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredTenantList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests the execution of {@code FilterCommand} when multiple keywords are provided.
+     * Verifies that tenants with addresses containing any of the keywords are found.
+     */
+    @Test
+    public void execute_multipleKeywords_multipleTenantsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        AddressContainsKeywordsPredicate predicate = preparePredicate("Lower Kent Ridge Rd");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredTenantList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(JAMES, MIKE, OLIVER), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests the execution of {@code FilterCommand} when a partial keyword is provided.
+     * Verifies that tenants with addresses containing the partial keyword are found.
+     */
+    @Test
+    public void execute_partialKeyword_tenantsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        AddressContainsKeywordsPredicate predicate = preparePredicate("Kent");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredTenantList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(JAMES, MIKE, OLIVER), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests the execution of {@code FilterCommand} when a non-matching keyword is provided.
+     * Verifies that no tenants are found.
+     */
+    @Test
+    public void execute_nonMatchingKeyword_noTenantFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        AddressContainsKeywordsPredicate predicate = preparePredicate("NonMatchingAddress");
+        FilterCommand command = new FilterCommand(predicate);
+        expectedModel.updateFilteredTenantList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    /**
+     * Tests the {@code toString} method of {@code FilterCommand}.
+     * Verifies that the string representation of the command is correct.
+     */
+    @Test
+    public void toStringMethod() {
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(Arrays.asList("keyword"));
+        FilterCommand filterCommand = new FilterCommand(predicate);
+        String expected = FilterCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code AddressContainsKeywordsPredicate}.
+     */
+    private AddressContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new AddressContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
+
+/**
+ * Test class for {@code FilterCommandParser}.
+ */
+public class FilterCommandParserTest {
+    private FilterCommandParser parser = new FilterCommandParser();
+
+    /**
+     * Tests parsing an empty argument, expecting a parse exception.
+     */
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests parsing valid arguments, expecting a successful parse into a {@code FilterCommand}.
+     */
+    @Test
+    public void parse_validArgs_returnsFilterCommand() {
+        // no leading and trailing whitespaces
+        FilterCommand expectedFilterCommand =
+                new FilterCommand(new AddressContainsKeywordsPredicate(Arrays.asList("119077", "Ridge")));
+        assertParseSuccess(parser, "119077 Ridge", expectedFilterCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n 119077 \n \t Ridge  \t", expectedFilterCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -30,5 +30,4 @@ public class FindCommandParserTest {
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
-
 }

--- a/src/test/java/seedu/address/logic/parser/TenantTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TenantTrackerParserTest.java
@@ -17,10 +17,12 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
 import seedu.address.model.tenant.NameContainsKeywordsPredicate;
 import seedu.address.model.tenant.Tenant;
 import seedu.address.testutil.TenantBuilder;
@@ -64,6 +66,14 @@ public class TenantTrackerParserTest {
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FilterCommand command = (FilterCommand) parser
+                .parseCommand(FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FilterCommand(new AddressContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalTenants.java
+++ b/src/test/java/seedu/address/testutil/TypicalTenants.java
@@ -50,6 +50,16 @@ public class TypicalTenants {
             /* .withPhone("8482131").withEmail("hans@example.com") */
             .withAddress("chicago ave, 123456").build();
 
+    // Added Manually for FilterCommandTest
+    public static final Tenant JAMES = new TenantBuilder().withName("James", "Smith")
+            .withAddress("21 Lower Kent Ridge Rd, 119077").build();
+
+    public static final Tenant MIKE = new TenantBuilder().withName("Mike", "Johnson")
+            .withAddress("21 Lower Kent Ridge Rd, 119077").build();
+
+    public static final Tenant OLIVER = new TenantBuilder().withName("Oliver", "Jones")
+            .withAddress("21 Lower Kent Ridge Rd, 119077").build();
+
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Tenant AMY = new TenantBuilder().withName(VALID_GIVEN_NAME_AMY, VALID_FAMILY_NAME_AMY)
             /* .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY) */
@@ -76,6 +86,6 @@ public class TypicalTenants {
     }
 
     public static List<Tenant> getTypicalTenants() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE, JAMES, MIKE, OLIVER));
     }
 }


### PR DESCRIPTION
The current application lacks the ability to filter tenants based on their addresses. This limits users' ability to search for tenants residing in specific locations.

Let's add a new FilterCommand that allows users to filter tenants by address. The command will match tenants whose addresses contain any of the specified keywords, regardless of case.

The implementation includes:
* A new FilterCommand class to handle the filtering logic.
* A new AddressContainsKeywordsPredicate class to match tenants based on their addresses.
* Unit tests for the FilterCommand and AddressContainsKeywordsPredicate classes to ensure correctness.
* Updates to the TypicalTenants class to include tenants with specific addresses for testing.

This feature improves the application's usability by enabling users to quickly find tenants based on their addresses.

Fixes #49 