### PR TITLE
Edit tenant

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FAMILY_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GIVEN_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -36,12 +37,13 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
-            + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) " + "[" + PREFIX_GIVEN_NAME + "NAME] " + "["
-            + PREFIX_PHONE + "PHONE] " + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_ADDRESS + "ADDRESS] " + "["
-            + PREFIX_TAG + "TAG]...\n" + "Example: " + COMMAND_WORD + " 1 " + PREFIX_PHONE + "91234567 " + PREFIX_EMAIL
-            + "johndoe@example.com";
+        + "by the index number used in the displayed person list. "
+        + "Existing values will be overwritten by the input values.\n"
+        + "Parameters: INDEX (must be a positive integer) " + "[" + PREFIX_GIVEN_NAME + "GIVEN NAME "
+        + PREFIX_FAMILY_NAME + "FAMILY NAME] " + "[" + PREFIX_PHONE + "PHONE] "
+        + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_ADDRESS + "ADDRESS] " + "["
+        + PREFIX_TAG + "TAG]...\n" + "Example: " + COMMAND_WORD + " 1 " + PREFIX_PHONE
+        + "91234567 " + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -51,15 +53,15 @@ public class EditCommand extends Command {
     private final EditTenantDescriptor editTenantDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
-     * @param editPersonDescriptor details to edit the person with
+     * @param index                of the person in the filtered person list to edit
+     * @param editTenantDescriptor details to edit the person with
      */
-    public EditCommand(Index index, EditTenantDescriptor editPersonDescriptor) {
+    public EditCommand(Index index, EditTenantDescriptor editTenantDescriptor) {
         requireNonNull(index);
-        requireNonNull(editPersonDescriptor);
+        requireNonNull(editTenantDescriptor);
 
         this.index = index;
-        this.editTenantDescriptor = new EditTenantDescriptor(editPersonDescriptor);
+        this.editTenantDescriptor = new EditTenantDescriptor(editTenantDescriptor);
     }
 
     @Override
@@ -112,13 +114,13 @@ public class EditCommand extends Command {
 
         EditCommand otherEditCommand = (EditCommand) other;
         return index.equals(otherEditCommand.index)
-                && editTenantDescriptor.equals(otherEditCommand.editTenantDescriptor);
+            && editTenantDescriptor.equals(otherEditCommand.editTenantDescriptor);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("index", index).add("editTenantDescriptor", editTenantDescriptor)
-                .toString();
+            .toString();
     }
 
     /**
@@ -132,7 +134,8 @@ public class EditCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        public EditTenantDescriptor() {}
+        public EditTenantDescriptor() {
+        }
 
         /**
          * Copy constructor. A defensive copy of {@code tags} is used internally.
@@ -213,16 +216,16 @@ public class EditCommand extends Command {
 
             EditTenantDescriptor otherEditPersonDescriptor = (EditTenantDescriptor) other;
             return Objects.equals(name, otherEditPersonDescriptor.name)
-                    && Objects.equals(phone, otherEditPersonDescriptor.phone)
-                    && Objects.equals(email, otherEditPersonDescriptor.email)
-                    && Objects.equals(address, otherEditPersonDescriptor.address)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                && Objects.equals(phone, otherEditPersonDescriptor.phone)
+                && Objects.equals(email, otherEditPersonDescriptor.email)
+                && Objects.equals(address, otherEditPersonDescriptor.address)
+                && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this).add("name", name).add("phone", phone).add("email", email)
-                    .add("address", address).add("tags", tags).toString();
+                .add("address", address).add("tags", tags).toString();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -69,11 +69,16 @@ public class EditCommand extends Command {
         requireNonNull(model);
         List<Tenant> lastShownList = model.getFilteredTenantList();
 
+        assert lastShownList != null : "Filtered tenant list should not be null";
+
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Tenant tenantToEdit = lastShownList.get(index.getZeroBased());
+
+        assert tenantToEdit != null : "Tenant to edit should not be null";
+
         Tenant editedTenant = createEditedPerson(tenantToEdit, editTenantDescriptor);
 
         if (!tenantToEdit.isSamePerson(editedTenant) && model.hasTenant(editedTenant)) {
@@ -91,6 +96,7 @@ public class EditCommand extends Command {
      */
     private static Tenant createEditedPerson(Tenant personToEdit, EditTenantDescriptor editPersonDescriptor) {
         assert personToEdit != null;
+        assert editPersonDescriptor != null : "EditTenantDescriptor should not be null";
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -49,6 +49,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditTenantDescriptor editPersonDescriptor = new EditTenantDescriptor();
 
+
         if (argMultimap.getValue(PREFIX_GIVEN_NAME).isPresent()
             || argMultimap.getValue(PREFIX_FAMILY_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_GIVEN_NAME).get(),

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -34,7 +34,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GIVEN_NAME, PREFIX_FAMILY_NAME,
-                PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+            PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
         Index index;
 
@@ -45,14 +45,14 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_GIVEN_NAME, PREFIX_FAMILY_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS);
+            PREFIX_ADDRESS);
 
         EditTenantDescriptor editPersonDescriptor = new EditTenantDescriptor();
 
         if (argMultimap.getValue(PREFIX_GIVEN_NAME).isPresent()
-                || argMultimap.getValue(PREFIX_FAMILY_NAME).isPresent()) {
+            || argMultimap.getValue(PREFIX_FAMILY_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_GIVEN_NAME).get(),
-                    argMultimap.getValue(PREFIX_FAMILY_NAME).get()));
+                argMultimap.getValue(PREFIX_FAMILY_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
             editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -106,8 +106,8 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_HDB + TAG_DESC_LANDED, Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
-            Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY
+            + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -21,6 +21,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_FAMILY_NAME_AMY
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GIVEN_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HDB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_LANDED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -29,6 +30,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +51,7 @@ public class EditCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
 
@@ -105,23 +107,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
-                Name.MESSAGE_CONSTRAINTS);
-    }
-
-    @Test
-    public void parse_allFieldsSpecified_success() {
-        // TODO: Implement this test
-        // Index targetIndex = INDEX_SECOND_PERSON;
-        // String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HDB + EMAIL_DESC_AMY +
-        // ADDRESS_DESC_AMY
-        // + NAME_DESC_AMY + TAG_DESC_LANDED;
-
-        // EditTenantDescriptor descriptor =
-        // new EditTenantDescriptorBuilder().withName(VALID_GIVEN_NAME_AMY, VALID_FAMILY_NAME_AMY)
-        // .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_HDB, VALID_TAG_LANDED).build();
-        // EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
-
-        // assertParseSuccess(parser, userInput, expectedCommand);
+            Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
@@ -130,7 +116,23 @@ public class EditCommandParserTest {
         String userInput = String.valueOf(targetIndex.getOneBased()) + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditTenantDescriptor descriptor =
-                new EditTenantDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).build();
+            new EditTenantDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        // TODO: Implement this test
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HDB + EMAIL_DESC_AMY
+            + ADDRESS_DESC_AMY
+            + NAME_DESC_AMY + TAG_DESC_LANDED;
+
+        EditTenantDescriptor descriptor =
+            new EditTenantDescriptorBuilder().withName(VALID_GIVEN_NAME_AMY, VALID_FAMILY_NAME_AMY)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
+                .withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_HDB, VALID_TAG_LANDED).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -142,7 +144,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditTenantDescriptor descriptor =
-                new EditTenantDescriptorBuilder().withName(VALID_GIVEN_NAME_AMY, VALID_FAMILY_NAME_AMY).build();
+            new EditTenantDescriptorBuilder().withName(VALID_GIVEN_NAME_AMY, VALID_FAMILY_NAME_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -191,17 +193,17 @@ public class EditCommandParserTest {
 
         // mulltiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + PHONE_DESC_BOB
-                + EMAIL_DESC_BOB + ADDRESS_DESC_BOB;
+            + EMAIL_DESC_BOB + ADDRESS_DESC_BOB;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+            Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
 
         // multiple invalid values
         userInput = String.valueOf(targetIndex.getOneBased()) + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC
-                + INVALID_EMAIL_DESC + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
+            + INVALID_EMAIL_DESC + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+            Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/TenantTrackerParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TenantTrackerParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FAMILY_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GIVEN_NAME_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -16,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditCommand.EditTenantDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -25,6 +29,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tenant.AddressContainsKeywordsPredicate;
 import seedu.address.model.tenant.NameContainsKeywordsPredicate;
 import seedu.address.model.tenant.Tenant;
+import seedu.address.testutil.EditTenantDescriptorBuilder;
 import seedu.address.testutil.TenantBuilder;
 import seedu.address.testutil.TenantUtil;
 
@@ -48,19 +53,22 @@ public class TenantTrackerParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser
-                .parseCommand(DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+            .parseCommand(DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
     public void parseCommand_edit() throws Exception {
         // TODO: Implement edit command
-        // Tenant person = new TenantBuilder().build();
-        // EditTenantDescriptor descriptor = new EditTenantDescriptorBuilder(person).build();
-        // EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-        // + INDEX_FIRST_PERSON.getOneBased() + " " +
-        // TenantUtil.getEditPersonDescriptorDetails(descriptor));
-        // assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+        Tenant person = new TenantBuilder().build();
+        EditTenantDescriptor descriptor = new EditTenantDescriptorBuilder(person)
+            .withName(VALID_GIVEN_NAME_BOB, VALID_FAMILY_NAME_BOB).build();
+        EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD
+            + " "
+            + INDEX_FIRST_PERSON.getOneBased()
+            + " "
+            + TenantUtil.getEditPersonDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
@@ -73,7 +81,7 @@ public class TenantTrackerParserTest {
     public void parseCommand_filter() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FilterCommand command = (FilterCommand) parser
-                .parseCommand(FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+            .parseCommand(FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FilterCommand(new AddressContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -81,7 +89,7 @@ public class TenantTrackerParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser
-                .parseCommand(FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+            .parseCommand(FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -100,7 +108,7 @@ public class TenantTrackerParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, /* Placeholder comment because checkstyle is a bitch */ String
-                .format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
+            .format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TenantUtil.java
+++ b/src/test/java/seedu/address/testutil/TenantUtil.java
@@ -45,7 +45,9 @@ public class TenantUtil {
      */
     public static String getEditPersonDescriptorDetails(EditTenantDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(PREFIX_GIVEN_NAME).append(name.familyName).append(" "));
+        descriptor.getName().ifPresent(name -> sb.append(PREFIX_GIVEN_NAME)
+            .append(name.givenName).append(" ")
+            .append(PREFIX_FAMILY_NAME).append(name.familyName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));


### PR DESCRIPTION
Ensure both givenName and familyName are included when formatting names.

Replace unsafe .get() calls with orElse(Collections.emptySet()) to prevent NoSuchElementException.

Trim trailing spaces in the generated string to ensure a valid command format.