### PR TITLE
Update naming in undo/redo state diagrams

### DIFF
--- a/docs/diagrams/UndoRedoState0.puml
+++ b/docs/diagrams/UndoRedoState0.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title Initial state
 
 package States {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab2:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab2:TenantTrack</u>"
 }
 State1 -[hidden]right-> State2
 State2 -[hidden]right-> State3

--- a/docs/diagrams/UndoRedoState1.puml
+++ b/docs/diagrams/UndoRedoState1.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "delete 5"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab2:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab2:TenantTrack</u>"
 }
 
 State1 -[hidden]right-> State2

--- a/docs/diagrams/UndoRedoState2.puml
+++ b/docs/diagrams/UndoRedoState2.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "add n/David"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab2:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab2:TenantTrack</u>"
 }
 
 State1 -[hidden]right-> State2

--- a/docs/diagrams/UndoRedoState3.puml
+++ b/docs/diagrams/UndoRedoState3.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "undo"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab2:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab2:TenantTrack</u>"
 }
 
 State1 -[hidden]right-> State2

--- a/docs/diagrams/UndoRedoState4.puml
+++ b/docs/diagrams/UndoRedoState4.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "list"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab2:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab2:TenantTrack</u>"
 }
 
 State1 -[hidden]right-> State2

--- a/docs/diagrams/UndoRedoState5.puml
+++ b/docs/diagrams/UndoRedoState5.puml
@@ -7,9 +7,9 @@ skinparam ClassBackgroundColor #FFFFAA
 title After command "clear"
 
 package States <<rectangle>> {
-    class State1 as "<u>ab0:AddressBook</u>"
-    class State2 as "<u>ab1:AddressBook</u>"
-    class State3 as "<u>ab3:AddressBook</u>"
+    class State1 as "<u>ab0:TenantTrack</u>"
+    class State2 as "<u>ab1:TenantTrack</u>"
+    class State3 as "<u>ab3:TenantTrack</u>"
 }
 
 State1 -[hidden]right-> State2


### PR DESCRIPTION
The undo/redo state UML diagrams (`UndoRedoState0.puml` to `UndoRedoState5.puml`) contained incorrect naming references. Some instances of the project name were outdated and inconsistent.

Updating these files ensures consistency across documentation and aligns with the correct project name, `TenantTrack`.

Let's:
- Rename all occurrences of the incorrect project name in `UndoRedoState0.puml` to `UndoRedoState5.puml`.
- Ensure uniformity across the state diagrams.