### PR TITLE
List bug fix

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.logging.Logger;
+
 import seedu.address.model.Model;
 
 /**
@@ -13,12 +15,25 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_SUCCESS = "Here is the list of tenants!";
+    public static final String MESSAGE_EMPTY_LIST = "There are no tenants in the list. Add some tenants!";
 
+    private static final Logger logger = Logger.getLogger(ListCommand.class.getName());
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
+        logger.info("Executing ListCommand to list tenants.");
+
+        assert model.getFilteredTenantList() != null : "Filtered tenant list should not be null";
+
         model.updateFilteredTenantList(PREDICATE_SHOW_ALL_PERSONS);
+        if (model.getFilteredTenantList().isEmpty()) {
+            return new CommandResult(MESSAGE_EMPTY_LIST);
+        }
+
+        logger.info("Tenant list displayed successfully with " + model.getFilteredTenantList().size() + " tenants.");
+
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -69,6 +69,10 @@ public class LogicManagerTest {
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
+        assertCommandSuccess(listCommand, ListCommand.MESSAGE_EMPTY_LIST, model);
+
+        Tenant tenant = new TenantBuilder().build();
+        model.addTenant(tenant);
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalTenants.getEmptyTenantTracker;
 import static seedu.address.testutil.TypicalTenants.getTypicalTenantTracker;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -35,5 +36,11 @@ public class ListCommandTest {
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyList_showsEmptyMessage() {
+        Model emptyModel = new ModelManager(getEmptyTenantTracker(), new UserPrefs());
+        assertCommandSuccess(new ListCommand(), emptyModel, ListCommand.MESSAGE_EMPTY_LIST, emptyModel);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalTenants.java
+++ b/src/test/java/seedu/address/testutil/TypicalTenants.java
@@ -81,4 +81,8 @@ public class TypicalTenants {
     public static List<Tenant> getTypicalTenants() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE, JAMES, MIKE, OLIVER));
     }
+
+    public static TenantTracker getEmptyTenantTracker() {
+        return new TenantTracker();
+    }
 }


### PR DESCRIPTION
ListCommand: improve empty list handling

The list command currently shows the same success message regardless of
whether there are tenants or not. This creates a confusing user
experience when the list is empty.

Let's:
* Return a specific message when the list is empty
* Keep the original message when tenants exist
* Add tests for both scenarios in ListCommandTest
* Update LogicManagerTest to verify the behavior

The empty list message helps users understand the system state better
and prompts them to add tenants when needed. The changes maintain
backward compatibility while improving user feedback.

Tests were added to verify:
- Empty list returns the new message
- Populated list returns the original message
- LogicManager properly handles both cases

Fixes #86 