### PR TITLE
Unpaid Command feature, Update Tests and Revise UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -303,7 +303,27 @@ Details:
 
 Examples:
 
-* `paid` followed by `87654321` marks the tenant with the 87654321 phone number with a paid icon.
+* `paid` followed by `87654321` adds a paid icon to the tenant with the phone number: `87654321`.
+
+### Marking a tenant as not paid: `unpaid`
+
+Marks a tenant as not paid based on phone number. The paid icon is removed from the tenant details.
+
+Format:
+
+<pre style="background-color: #eeeefe; padding: 10px; border-radius: 5px; font-family: monospace; font-size: 14px; white-space: pre-wrap; word-wrap: break-word;">
+unpaid PHONE
+</pre>
+
+Details:
+
+* Searches the tenant with the specified phone number.
+* The phone number should be exactly 8 digits long.
+* The phone number should belong to a tenant that has paid.
+
+Examples:
+
+* `unpaid` followed by `87654321` removes the paid icon from the tenant with the phone number: `87654321`.
 
 ### Exiting the program: `exit`
 
@@ -386,5 +406,7 @@ corruption.
  **Edit**    | `edit INDEX [givenN/GIVEN_NAME] [familyN/FAMILY_NAME] [phone/PHONE_NUMBER] [email/EMAIL] [address/ADDRESS] [tag/TAG]…​` | `edit 2 givenN/ James familyN/ Lee email/ jameslee@example.com`
  **Find**    | `find KEYWORD [MORE_KEYWORDS]`                                                                                          | `find James Jake`
  **Filter**  | `filter KEYWORD [MORE_KEYWORDS]`                                                                                        | `filter Lower Kent Ridge`
- **List**    | `list`                                                                                                                  |
+ **List**    | `list`                                                                                                                  
+ **Paid**    | `paid phone/PHONE`                                                                                                      | `paid 87654321`
+ **UnPaid**  | `unpaid phone/PHONE`                                                                                                    | `unpaid 87654321`
  **Help**    | `help`                                                                                                                  |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -285,6 +285,26 @@ Examples:
 * `find Betsy` followed by `map 1` searches the 1st tenant in the results of the `find` command's address in Google
   Maps.
 
+### Marking a tenant as paid: `paid`
+
+Marks a tenant as paid with a paid icon based on phone number.
+
+Format:
+
+<pre style="background-color: #eeeefe; padding: 10px; border-radius: 5px; font-family: monospace; font-size: 14px; white-space: pre-wrap; word-wrap: break-word;">
+paid PHONE
+</pre>
+
+Details:
+
+* Searches the tenant with the specified phone number.
+* The phone number should be exactly 8 digits long.
+* If the phone number does not belong to any tenant, an error message is returned.
+
+Examples:
+
+* `paid` followed by `87654321` marks the tenant with the 87654321 phone number with a paid icon.
+
 ### Exiting the program: `exit`
 
 Exits the program.

--- a/src/main/java/seedu/address/logic/commands/UnpaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpaidCommand.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.tenant.Phone;
+import seedu.address.model.tenant.Tenant;
+
+/**
+ * Marks a tenant as not paid based on the provided phone number.
+ */
+public class UnpaidCommand extends Command {
+    public static final String COMMAND_WORD = "unpaid";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Marks the tenant with the specified phone number as not paid.\n"
+            + "Parameters: PHONE\n" + "Example: " + COMMAND_WORD + " 12345678";
+    public static final String MESSAGE_SUCCESS = "Tenant marked as not paid: %s";
+    public static final String MESSAGE_TENANT_NOT_FOUND = "No tenant found with phone number: %s";
+    public static final String MESSAGE_ALREADY_UNPAID = "Tenant with phone number: %s "
+            + "has already been marked as not paid.";
+
+    private final Phone phone;
+
+    public UnpaidCommand(Phone phone) {
+        this.phone = phone;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Tenant tenant = model.findTenantByPhone(phone);
+        if (tenant == null) {
+            throw new CommandException(String.format(MESSAGE_TENANT_NOT_FOUND, phone));
+        }
+
+        if (!tenant.isPaid()) {
+            throw new CommandException(String.format(MESSAGE_ALREADY_UNPAID, phone));
+        }
+
+        model.unmarkTenantAsPaid(phone);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, tenant.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof UnpaidCommand)) {
+            return false;
+        }
+        UnpaidCommand that = (UnpaidCommand) other;
+        return phone.equals(that.phone);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/TenantTrackerParser.java
+++ b/src/main/java/seedu/address/logic/parser/TenantTrackerParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MapCommand;
 import seedu.address.logic.commands.PaidCommand;
+import seedu.address.logic.commands.UnpaidCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -93,6 +94,10 @@ public class TenantTrackerParser {
 
         case PaidCommand.COMMAND_WORD:
             return new PaidCommandParser().parse(arguments, userInput);
+
+        case UnpaidCommand.COMMAND_WORD:
+            return new UnpaidCommandParser().parse(arguments, userInput);
+
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/UnpaidCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnpaidCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.UnpaidCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tenant.Phone;
+
+/**
+ * Parses input arguments and creates a new UnpaidCommand object
+ */
+public class UnpaidCommandParser implements Parser<UnpaidCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnpaidCommand
+     * and returns an UnpaidCommand object for execution.
+     *
+     * @param args the user input arguments.
+     * @param userInput the full user input string.
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public UnpaidCommand parse(String args, String userInput) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnpaidCommand.MESSAGE_USAGE));
+        }
+
+        Phone phone;
+        try {
+            phone = ParserUtil.parsePhone(trimmedArgs);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnpaidCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new UnpaidCommand(phone);
+    }
+}
+

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -116,4 +116,9 @@ public interface Model {
      * Finds a tenant based on their phone number.
      */
     Tenant findTenantByPhone(Phone phone);
+
+    /**
+     * Marks the tenant as not paid based on their phone number.
+     */
+    void unmarkTenantAsPaid(Phone phone);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -189,6 +189,21 @@ public class ModelManager implements Model {
         return null;
     }
 
+    /**
+     * Marks a tenant as not paid based on their phone number.
+     *
+     * @param phone the phone number of the tenant to mark as not paid
+     */
+    @Override
+    public void unmarkTenantAsPaid(Phone phone) {
+        requireNonNull(phone);
+        Tenant tenant = findTenantByPhone(phone);
+        if (tenant != null && tenant.isPaid()) {
+            tenant.setPaid(false);
+            updateFilteredTenantList(PREDICATE_SHOW_ALL_PERSONS);
+        }
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -184,6 +184,11 @@ public class AddCommandTest {
         public Tenant findTenantByPhone(Phone phone) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void unmarkTenantAsPaid(Phone phone) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     // /**

--- a/src/test/java/seedu/address/logic/commands/UnpaidCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnpaidCommandTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalTenants.getTypicalTenantTracker;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tenant.Phone;
+import seedu.address.model.tenant.Tenant;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnpaidCommand}.
+ */
+public class UnpaidCommandTest {
+
+    private Model model = new ModelManager(getTypicalTenantTracker(), new UserPrefs());
+
+    @Test
+    public void execute_tenantIsPaid_success() {
+        Tenant tenantToUnpay = model.getFilteredTenantList().get(0);
+
+        tenantToUnpay.markAsPaid();
+
+        Phone phone = tenantToUnpay.getPhone();
+        UnpaidCommand unpaidCommand = new UnpaidCommand(phone);
+
+        String expectedMessage = String.format(UnpaidCommand.MESSAGE_SUCCESS, tenantToUnpay.getName());
+
+        ModelManager expectedModel = new ModelManager(model.getTenantTracker(), new UserPrefs());
+        Tenant expectedTenant = new Tenant(tenantToUnpay.getName(), tenantToUnpay.getPhone(),
+                tenantToUnpay.getEmail(), tenantToUnpay.getAddress(), tenantToUnpay.getTags(),
+                tenantToUnpay.isArchived(), false);
+
+        expectedModel.setPerson(tenantToUnpay, expectedTenant);
+
+        assertCommandSuccess(unpaidCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_tenantAlreadyUnpaid_throwsCommandException() {
+        Tenant unpaidTenant = model.getFilteredTenantList().get(0);
+        unpaidTenant.setPaid(false);
+
+        UnpaidCommand unpaidCommand = new UnpaidCommand(unpaidTenant.getPhone());
+        String expectedMessage = String.format(UnpaidCommand.MESSAGE_ALREADY_UNPAID, unpaidTenant.getPhone().value);
+
+        assertCommandFailure(unpaidCommand, model, expectedMessage);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/PaidCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PaidCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,11 @@ public class PaidCommandParserTest {
     private PaidCommandParser parser = new PaidCommandParser();
 
 
-    /* public void parse_emptyArgs_throwsParseException() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, PaidCommand.MESSAGE_USAGE);
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        String expectedMessage = String.format(PaidCommand.MESSAGE_USAGE);
         assertParseFailure(parser, "", expectedMessage);
-    } */
+    }
 
     /**
      * Tests parsing valid arguments, expecting a successful parse into a {@code PaidCommand}.
@@ -34,14 +36,15 @@ public class PaidCommandParserTest {
         assertParseSuccess(parser, "  12345678  ", expectedCommand);
     }
 
-    /*public void parse_invalidArgs_throwsParseException() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, PaidCommand.MESSAGE_USAGE);
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String expectedMessage = String.format(PaidCommand.MESSAGE_USAGE);
 
         // Test with invalid phone number containing letters
         assertParseFailure(parser, "abc123", expectedMessage.trim());
 
         // Test with an incomplete phone number
         assertParseFailure(parser, "1234567", expectedMessage.trim());
-    }*/
+    }
 }
 

--- a/src/test/java/seedu/address/logic/parser/UnpaidCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnpaidCommandParserTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UnpaidCommand;
+import seedu.address.model.tenant.Phone;
+
+/**
+ * Contains tests for {@code UnpaidCommandParser}.
+ */
+public class UnpaidCommandParserTest {
+
+    private UnpaidCommandParser parser = new UnpaidCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        String expectedMessage = String.format(UnpaidCommand.MESSAGE_USAGE);
+        // Test with empty string
+        assertParseFailure(parser, "", expectedMessage);
+        // Test with spaces only
+        assertParseFailure(parser, "     ", expectedMessage);
+    }
+
+    @Test
+    public void parse_validArgs_returnsUnpaidCommand() {
+        // Test with valid phone number
+        Phone phone = new Phone("12345678");
+        UnpaidCommand expectedCommand = new UnpaidCommand(phone);
+        assertParseSuccess(parser, "12345678", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        String expectedMessage = String.format(UnpaidCommand.MESSAGE_USAGE);
+        // Test with invalid phone number containing letters
+        assertParseFailure(parser, "abc123", expectedMessage);
+        // Test with incomplete phone number
+        assertParseFailure(parser, "1234567", expectedMessage);
+    }
+}


### PR DESCRIPTION


Add 'unpaid' command and update user guide

Implement the UnpaidCommand and UnpaidCommandParser classes to introduce the 'unpaid' command, which sets the payment status of tenants to not paid. This update ensures immediate UI feedback without the need for application restarts.

Changes include:
- Creation of UnpaidCommand and UnpaidCommandParser for handling the new command logic.
- Modifications in Model and ModelManager to manage payment status updates.
- Immediate reflection of payment status in TenantCard UI.
- Updated `PaidCommandTest` and `PaidCommandParserTest` to align with current functionalities and added negative tests.
- Created test classes `UnpaidCommandTest` and `UnpaidCommandParserTest`
- Updated the user guide to document the new 'unpaid' and 'paid' command usage.

This update not only enhances the application by allowing real-time updates to tenant statuses but also improves user guidance through updated documentation, making the feature easily accessible and usable.

Refer to the user guide section for detailed instructions and examples on using the 'unpaid' command.
