### PR TITLE
Show available fields when none are specified

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -46,7 +46,8 @@ public class EditCommand extends Command {
         + "91234567 " + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided. eg. givenN/name |"
+        + " familyN/ surname | tag/ | address/ | phone| ";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;


### PR DESCRIPTION
Previously, when a user entered an edit command with no fields (e.g., `edit 1`), the app returned a generic error message without guiding the user on what fields can be edited.

This was unhelpful, especially for new users unfamiliar with the command format.

Let's update the error message to list the editable fields and provide an example usage to improve clarity.

This enhances user guidance and reduces confusion during command usage.