### PR TITLE
Filter Bug Fixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -116,7 +116,7 @@ A tenant can have any number of tags (including 0).
 Examples:
 
 * `add givenN/ John familyN/ Doe phone/ 98765432 email/ johnd@example.com address/ John street, block 123, #01-01 123456`
-* `add givenN/ Sam familyN/ Wilson phone/ 87543213 email/ samw@example.com address/ Sam street, block 321, #02-04 456423`
+* `add givenN/ Sam familyN/ Tan phone/ 87543213 email/ sam@example.com address/ Sam street, block 321, #02-04 456423`
 
 ### Archiving a tenant: `archive`
 


### PR DESCRIPTION
Modify the example for add command in UG
-Previously, if reader copied the command line by line instead of the whole command together, he would have missed out on a whitespace between the email and address prefix. Due to pdf saving, the wrapping to a newline might have caused readers to miss out the whitespace
-Modify the example to not wrap just before the address prefix
- Fixes #157 