### PR TITLE
Add Paid and Unpaid features to HelpWindow

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -527,6 +527,7 @@ unpaid 98765432
 **Notes**
 
 * The phone number must belong to an existing tenant.
+* The phone number should be a valid Singaporean phone number exactly 8 digits long and starting with 6, 8 or 9.
 * If the tenant is already marked as paid or unpaid, an appropriate error message is displayed.
 * The `isPaid` property ensures that the tenant's payment status is tracked accurately.
 
@@ -1291,7 +1292,7 @@ testers are expected to do more *exploratory* testing.
        Expected: A new tenant named John Doe is added to the list. A success message is displayed.
 
     1. Test case: `add givenN/ John familyN/ Doe phone/ 12345678 email/ johnd@example.com address/ John street, block 123, #01-01 S123456`<br>
-       Expected: No tenant is added. Error details are shown in the status message.
+       Expected: No tenant is added as `12345678` is an invalid phone number. Error details are shown in the status message.
 
 ### Editing a tenant
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -312,7 +312,7 @@ paid PHONE
 Details:
 
 * Searches the tenant with the specified phone number in the active tenant list.
-* The phone number should be exactly 8 digits long.
+* The phone number should be a valid Singaporean phone number exactly 8 digits long and starting with 6, 8 or 9.
 * If the phone number does not belong to any tenant, an error message is returned.
 
 Examples:
@@ -369,7 +369,7 @@ unpaid PHONE
 Details:
 
 * Searches the tenant with the specified phone number in the active tenant list.
-* The phone number should be exactly 8 digits long.
+* The phone number should be a valid Singaporean phone number exactly 8 digits long and starting with 6, 8 or 9.
 * The phone number should belong to a tenant that has paid.
 
 Examples:

--- a/src/main/java/seedu/address/logic/commands/PaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PaidCommand.java
@@ -17,7 +17,8 @@ public class PaidCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the tenant with the specified phone number as paid.\n"
             + "Parameters: PHONE\n"
-            + "Example: " + COMMAND_WORD + " 12345678";
+            + "Example: " + COMMAND_WORD + " 82345678\n"
+            + "The phone number should be a valid Singaporean phone number also.";
 
     public static final String MESSAGE_SUCCESS = "Successfully marked tenant as paid: %s";
     public static final String MESSAGE_TENANT_NOT_FOUND = "No tenant found with phone number: %s";

--- a/src/main/java/seedu/address/logic/commands/UnpaidCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnpaidCommand.java
@@ -12,7 +12,8 @@ public class UnpaidCommand extends Command {
     public static final String COMMAND_WORD = "unpaid";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the tenant with the specified phone number as not paid.\n"
-            + "Parameters: PHONE\n" + "Example: " + COMMAND_WORD + " 12345678";
+            + "Parameters: PHONE\n" + "Example: " + COMMAND_WORD + " 82345678\n"
+            + "The phone number should be a valid Singaporean phone number also.";
     public static final String MESSAGE_SUCCESS = "Tenant marked as not paid: %s";
     public static final String MESSAGE_TENANT_NOT_FOUND = "No tenant found with phone number: %s";
     public static final String MESSAGE_ALREADY_UNPAID = "Tenant with phone number: %s "

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -53,6 +53,12 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private TextArea mapHelp;
 
+    @FXML
+    private TextArea paidHelp;
+
+    @FXML
+    private TextArea unpaidHelp;
+
     /**
      * Creates a new HelpWindow.
      *
@@ -136,6 +142,23 @@ public class HelpWindow extends UiPart<Stage> {
             map 1
             """);
 
+        paidHelp.setText("""
+            paid: Marks a tenant as paid with a paid icon based on phone number.
+
+            Parameters:
+            PHONE (must be a valid Singaporean Phone number)
+
+            Example:
+            paid 91234567""");
+
+        unpaidHelp.setText("""
+            unpaid: Marks a tenant as not paid based on phone number. Removes the paid icon.
+
+            Parameters:
+            PHONE (must be a valid Singaporean Phone number)
+
+            Example:
+            unpaid 91234567""");
         root.setMinWidth(600);
         root.setMinHeight(100);
         root.setWidth(600);

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -143,6 +143,16 @@
                                       style="-fx-font-family: monospace; -fx-font-size: 13px;"
                                       prefRowCount="6">
                             </TextArea>
+
+                            <!-- 💵 Paid UnPaid Command -->
+                            <Label text="💵️ Paid Command" style="-fx-font-weight: bold;"/>
+                            <TextArea fx:id="paidHelp" editable="false" wrapText="true"
+                                      style="-fx-font-family: monospace; -fx-font-size: 13px;" prefRowCount="6">
+                            </TextArea>
+                            <Label text="💸 Unpaid Command" style="-fx-font-weight: bold;"/>
+                            <TextArea fx:id="unpaidHelp" editable="false" wrapText="true"
+                                      style="-fx-font-family: monospace; -fx-font-size: 13px;" prefRowCount="6">
+                            </TextArea>
                         </VBox>
                     </ScrollPane>
                 </TitledPane>


### PR DESCRIPTION
Previously, the Help Window did not contain the Unpaid and Paid command. Adding the Paid and Unpaid Command to the HelpWindow ensures users are aware of these 2 commands also.

Additionally, update the paid details in the UG and DG to reflect valid Singaporean phone number and error message display of the paid and unpaid command.